### PR TITLE
tnl login: use PAR + /auth/login (fixes redirect_uri rejection)

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -70,9 +70,6 @@ Examples:
 				return fmt.Errorf("guardian login failed: %w", err)
 			}
 			token = result.AccessToken
-			if result.ExpiresIn > 0 {
-				fmt.Printf("Received access token (valid for %s).\n", (time.Duration(result.ExpiresIn) * time.Second).String())
-			}
 		}
 
 		// Save token to config with original server string to preserve all details

--- a/internal/guardian/oidc.go
+++ b/internal/guardian/oidc.go
@@ -3,7 +3,6 @@ package guardian
 import (
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -15,47 +14,46 @@ import (
 	"time"
 )
 
-// LoginConfig configures the OIDC authorization-code + PKCE login flow used
-// by the CLI. Guardian is a public-client IdP (token_endpoint_auth_methods =
-// ["none"]) so no client secret is involved; PKCE S256 is mandatory.
+// LoginConfig configures the browser SSO login flow used by the CLI.
+//
+// Guardian's /oauth/authorize only honors a service's exact registered
+// redirect URIs; dynamic/localhost callbacks (registered as "extra redirect
+// URI patterns") are honored exclusively via PAR (RFC 9126) + /auth/login.
+// So the CLI flow is:
+//
+//  1. POST /api/v1/oauth/par with client_id + redirect_uri + state
+//     -> single-use request_uri (90s TTL)
+//  2. open the browser at /auth/login?client_id=...&request_uri=...
+//  3. Guardian runs SSO and redirects back to the localhost callback with
+//     ?token=<access JWT>&state=<state> - no code exchange step.
 type LoginConfig struct {
 	// GuardianURL is the Guardian base URL, e.g. https://id.stable.dexus.io
 	GuardianURL string
 	// ClientID is the registered service client ID, e.g. svc_tiny-tunnel_stable
 	ClientID string
 	// CallbackPort is the localhost port for the redirect URI. The redirect
-	// URI http://localhost:<port>/auth/callback must be registered with the
-	// service in Guardian.
+	// URI http://localhost:<port>/auth/callback must be registered as an
+	// extra redirect URI pattern on the service in Guardian.
 	CallbackPort int
-	// OpenBrowser is called with the authorization URL. If nil or it errors,
-	// the URL is expected to be presented to the user by the caller via
+	// OpenBrowser is called with the login URL. If nil or it errors, the URL
+	// is expected to be presented to the user by the caller via
 	// AuthURLCallback.
 	OpenBrowser func(url string) error
-	// AuthURLCallback, if set, receives the authorization URL (for printing).
+	// AuthURLCallback, if set, receives the login URL (for printing).
 	AuthURLCallback func(url string)
 	// Timeout bounds the whole flow (default 5 minutes).
 	Timeout time.Duration
-	// HTTPClient overrides the client used for discovery/token calls.
+	// HTTPClient overrides the client used for the PAR call.
 	HTTPClient *http.Client
 }
 
 // TokenResult is the outcome of a successful login.
 type TokenResult struct {
-	AccessToken  string
-	RefreshToken string
-	IDToken      string
-	ExpiresIn    int
+	AccessToken string
 }
 
-type discoveryDoc struct {
-	Issuer                string `json:"issuer"`
-	AuthorizationEndpoint string `json:"authorization_endpoint"`
-	TokenEndpoint         string `json:"token_endpoint"`
-}
-
-// Login runs the full authorization-code + PKCE flow: starts a localhost
-// callback listener, opens the browser to Guardian's authorize endpoint, and
-// exchanges the returned code for tokens.
+// Login runs the PAR + browser SSO flow and returns the Guardian access
+// token delivered to the localhost callback.
 func Login(ctx context.Context, cfg LoginConfig) (*TokenResult, error) {
 	if cfg.GuardianURL == "" || cfg.ClientID == "" {
 		return nil, errors.New("guardian url and client id are required")
@@ -70,31 +68,18 @@ func Login(ctx context.Context, cfg LoginConfig) (*TokenResult, error) {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: 15 * time.Second}
 	}
+	baseURL := strings.TrimSuffix(cfg.GuardianURL, "/")
 
 	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
 
-	// Discovery
-	disc, err := discover(ctx, httpClient, cfg.GuardianURL)
-	if err != nil {
-		return nil, err
-	}
-
-	// PKCE material
-	verifier, err := randomURLSafe(32)
-	if err != nil {
-		return nil, err
-	}
-	sum := sha256.Sum256([]byte(verifier))
-	challenge := base64.RawURLEncoding.EncodeToString(sum[:])
 	state, err := randomURLSafe(16)
 	if err != nil {
 		return nil, err
 	}
-
 	redirectURI := fmt.Sprintf("http://localhost:%d/auth/callback", cfg.CallbackPort)
 
-	// Callback listener — bind before opening the browser so we can't miss
+	// Callback listener — bind before starting the flow so we can't miss
 	// the redirect.
 	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.CallbackPort))
 	if err != nil {
@@ -103,8 +88,8 @@ func Login(ctx context.Context, cfg LoginConfig) (*TokenResult, error) {
 	defer listener.Close()
 
 	type callbackResult struct {
-		code string
-		err  error
+		token string
+		err   error
 	}
 	resultChan := make(chan callbackResult, 1)
 
@@ -124,126 +109,84 @@ func Login(ctx context.Context, cfg LoginConfig) (*TokenResult, error) {
 			resultChan <- callbackResult{err: errors.New("state mismatch in callback")}
 			return
 		}
-		code := q.Get("code")
-		if code == "" {
-			http.Error(w, "Missing code", http.StatusBadRequest)
-			resultChan <- callbackResult{err: errors.New("callback missing authorization code")}
+		token := q.Get("token")
+		if token == "" {
+			http.Error(w, "Missing token", http.StatusBadRequest)
+			resultChan <- callbackResult{err: errors.New("callback missing token")}
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		fmt.Fprint(w, `<html><body style="font-family: sans-serif; text-align: center; padding-top: 4rem;">
 <h2>Login successful</h2><p>You can close this tab and return to the terminal.</p>
 </body></html>`)
-		resultChan <- callbackResult{code: code}
+		resultChan <- callbackResult{token: token}
 	})}
 	go server.Serve(listener)
 	defer server.Close()
 
-	// Authorization URL
-	authURL, err := url.Parse(disc.AuthorizationEndpoint)
-	if err != nil {
-		return nil, fmt.Errorf("invalid authorization endpoint: %w", err)
+	// Step 1: PAR — push the authorization request, get a request_uri.
+	// This is what grants the localhost redirect URI provenance; direct
+	// /auth/login query params only match exact registered URIs.
+	form := url.Values{
+		"client_id":    {cfg.ClientID},
+		"redirect_uri": {redirectURI},
+		"state":        {state},
 	}
-	q := authURL.Query()
-	q.Set("response_type", "code")
-	q.Set("client_id", cfg.ClientID)
-	q.Set("redirect_uri", redirectURI)
-	q.Set("scope", "openid email profile")
-	q.Set("state", state)
-	q.Set("code_challenge", challenge)
-	q.Set("code_challenge_method", "S256")
-	authURL.RawQuery = q.Encode()
+	parReq, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/api/v1/oauth/par", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	parReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	parResp, err := httpClient.Do(parReq)
+	if err != nil {
+		return nil, fmt.Errorf("par request: %w", err)
+	}
+	defer parResp.Body.Close()
+
+	if parResp.StatusCode != http.StatusCreated && parResp.StatusCode != http.StatusOK {
+		var e struct {
+			Error       string `json:"error"`
+			Description string `json:"error_description"`
+		}
+		_ = json.NewDecoder(parResp.Body).Decode(&e)
+		return nil, fmt.Errorf("par request failed (%d): %s %s", parResp.StatusCode, e.Error, e.Description)
+	}
+
+	var par struct {
+		RequestURI string `json:"request_uri"`
+		ExpiresIn  int    `json:"expires_in"`
+	}
+	if err := json.NewDecoder(parResp.Body).Decode(&par); err != nil {
+		return nil, fmt.Errorf("decode par response: %w", err)
+	}
+	if par.RequestURI == "" {
+		return nil, errors.New("par response has no request_uri")
+	}
+
+	// Step 2: send the browser to /auth/login with the opaque request_uri.
+	// Note the request_uri is single-use with a ~90s TTL — it's consumed as
+	// soon as the browser hits /auth/login, so a slow SSO after that is fine.
+	loginURL := fmt.Sprintf("%s/auth/login?client_id=%s&request_uri=%s",
+		baseURL, url.QueryEscape(cfg.ClientID), url.QueryEscape(par.RequestURI))
 
 	if cfg.AuthURLCallback != nil {
-		cfg.AuthURLCallback(authURL.String())
+		cfg.AuthURLCallback(loginURL)
 	}
 	if cfg.OpenBrowser != nil {
-		_ = cfg.OpenBrowser(authURL.String()) // failure is fine; URL was shown
+		_ = cfg.OpenBrowser(loginURL) // failure is fine; URL was shown
 	}
 
-	// Wait for the callback
-	var code string
+	// Step 3: wait for the token to arrive on the callback.
 	select {
 	case res := <-resultChan:
 		if res.err != nil {
 			return nil, res.err
 		}
-		code = res.code
+		return &TokenResult{AccessToken: res.token}, nil
 	case <-ctx.Done():
 		return nil, fmt.Errorf("timed out waiting for login: %w", ctx.Err())
 	}
-
-	// Code exchange (public client: no secret, PKCE verifier is the proof)
-	form := url.Values{
-		"grant_type":    {"authorization_code"},
-		"code":          {code},
-		"redirect_uri":  {redirectURI},
-		"client_id":     {cfg.ClientID},
-		"code_verifier": {verifier},
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, disc.TokenEndpoint, strings.NewReader(form.Encode()))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("token exchange: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		var e struct {
-			Error       string `json:"error"`
-			Description string `json:"error_description"`
-		}
-		_ = json.NewDecoder(resp.Body).Decode(&e)
-		return nil, fmt.Errorf("token exchange failed (%d): %s %s", resp.StatusCode, e.Error, e.Description)
-	}
-
-	var out struct {
-		AccessToken  string `json:"access_token"`
-		RefreshToken string `json:"refresh_token"`
-		IDToken      string `json:"id_token"`
-		ExpiresIn    int    `json:"expires_in"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return nil, fmt.Errorf("decode token response: %w", err)
-	}
-	if out.AccessToken == "" {
-		return nil, errors.New("token response has no access_token")
-	}
-
-	return &TokenResult{
-		AccessToken:  out.AccessToken,
-		RefreshToken: out.RefreshToken,
-		IDToken:      out.IDToken,
-		ExpiresIn:    out.ExpiresIn,
-	}, nil
-}
-
-func discover(ctx context.Context, httpClient *http.Client, baseURL string) (*discoveryDoc, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSuffix(baseURL, "/")+"/.well-known/openid-configuration", nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("oidc discovery: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("oidc discovery: unexpected status %d", resp.StatusCode)
-	}
-	var doc discoveryDoc
-	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
-		return nil, fmt.Errorf("oidc discovery: %w", err)
-	}
-	if doc.AuthorizationEndpoint == "" || doc.TokenEndpoint == "" {
-		return nil, errors.New("oidc discovery: incomplete document")
-	}
-	return &doc, nil
 }
 
 func randomURLSafe(nBytes int) (string, error) {

--- a/internal/guardian/oidc_test.go
+++ b/internal/guardian/oidc_test.go
@@ -2,8 +2,6 @@ package guardian
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -16,41 +14,49 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// fakeIdP implements the discovery, authorize, and token endpoints with
-// mandatory PKCE S256 semantics matching Guardian's public-client model.
+// newFakeIdP implements Guardian's PAR + /auth/login flow: PAR stores the
+// pushed parameters, /auth/login consumes the single-use request_uri and
+// redirects back to the stored redirect_uri with ?token=...&state=...
 func newFakeIdP(t *testing.T) *httptest.Server {
 	t.Helper()
 
-	var storedChallenge string
-	const authCode = "test-auth-code"
+	type parEntry struct {
+		redirectURI string
+		state       string
+	}
+	parStore := map[string]parEntry{}
 
 	mux := http.NewServeMux()
 	var server *httptest.Server
 
-	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
-			"issuer":                 server.URL,
-			"authorization_endpoint": server.URL + "/oauth/authorize",
-			"token_endpoint":         server.URL + "/oauth/token",
-			"jwks_uri":               server.URL + "/.well-known/jwks.json",
-		})
+	mux.HandleFunc("/api/v1/oauth/par", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "svc_test", r.Form.Get("client_id"))
+		redirectURI := r.Form.Get("redirect_uri")
+		require.NotEmpty(t, redirectURI)
+
+		requestURI := "urn:guardian:par:test-" + fmt.Sprint(len(parStore))
+		parStore[requestURI] = parEntry{redirectURI: redirectURI, state: r.Form.Get("state")}
+
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"request_uri": requestURI, "expires_in": 90})
 	})
 
-	mux.HandleFunc("/oauth/authorize", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/auth/login", func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
-		assert.Equal(t, "code", q.Get("response_type"))
 		assert.Equal(t, "svc_test", q.Get("client_id"))
-		assert.Equal(t, "S256", q.Get("code_challenge_method"))
-		require.NotEmpty(t, q.Get("code_challenge"))
-		require.NotEmpty(t, q.Get("state"))
-		storedChallenge = q.Get("code_challenge")
+		entry, ok := parStore[q.Get("request_uri")]
+		require.True(t, ok, "unknown or reused request_uri")
+		delete(parStore, q.Get("request_uri")) // single-use
 
-		// Simulate the user approving: redirect back with code + state.
-		redirect, err := url.Parse(q.Get("redirect_uri"))
+		// Simulate a successful SSO: redirect back with token + state.
+		redirect, err := url.Parse(entry.redirectURI)
 		require.NoError(t, err)
 		rq := redirect.Query()
-		rq.Set("code", authCode)
-		rq.Set("state", q.Get("state"))
+		rq.Set("token", "test-access-token")
+		if entry.state != "" {
+			rq.Set("state", entry.state)
+		}
 		redirect.RawQuery = rq.Encode()
 
 		resp, err := http.Get(redirect.String())
@@ -59,37 +65,23 @@ func newFakeIdP(t *testing.T) *httptest.Server {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
-	mux.HandleFunc("/oauth/token", func(w http.ResponseWriter, r *http.Request) {
-		require.NoError(t, r.ParseForm())
-		assert.Equal(t, "authorization_code", r.Form.Get("grant_type"))
-		assert.Equal(t, authCode, r.Form.Get("code"))
-		assert.Equal(t, "svc_test", r.Form.Get("client_id"))
-
-		// PKCE check: BASE64URL(SHA256(verifier)) == stored challenge
-		verifier := r.Form.Get("code_verifier")
-		require.NotEmpty(t, verifier)
-		sum := sha256.Sum256([]byte(verifier))
-		if base64.RawURLEncoding.EncodeToString(sum[:]) != storedChallenge {
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": "invalid_grant", "error_description": "code_verifier mismatch"})
-			return
-		}
-
-		json.NewEncoder(w).Encode(map[string]any{
-			"access_token":  "test-access-token",
-			"id_token":      "test-id-token",
-			"refresh_token": "test-refresh-token",
-			"token_type":    "Bearer",
-			"expires_in":    3600,
-		})
-	})
-
 	server = httptest.NewServer(mux)
 	t.Cleanup(server.Close)
 	return server
 }
 
-func TestLoginPKCEFlow(t *testing.T) {
+// browserFetch simulates opening the login URL in a browser.
+func browserFetch(u string) error {
+	go func() {
+		resp, err := http.Get(u)
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+	return nil
+}
+
+func TestLoginPARFlow(t *testing.T) {
 	idp := newFakeIdP(t)
 
 	result, err := Login(context.Background(), LoginConfig{
@@ -97,22 +89,10 @@ func TestLoginPKCEFlow(t *testing.T) {
 		ClientID:     "svc_test",
 		CallbackPort: 18085,
 		Timeout:      10 * time.Second,
-		// "Open the browser" by fetching the authorize URL; the fake IdP
-		// immediately follows the redirect back to our callback listener.
-		OpenBrowser: func(u string) error {
-			go func() {
-				resp, err := http.Get(u)
-				if err == nil {
-					resp.Body.Close()
-				}
-			}()
-			return nil
-		},
+		OpenBrowser:  browserFetch,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "test-access-token", result.AccessToken)
-	assert.Equal(t, "test-refresh-token", result.RefreshToken)
-	assert.Equal(t, 3600, result.ExpiresIn)
 }
 
 func TestLoginTimeout(t *testing.T) {
@@ -134,20 +114,42 @@ func TestLoginRequiresConfig(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestLoginPARRejection(t *testing.T) {
+	// IdP that rejects the PAR request (e.g. unregistered redirect_uri).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/oauth/par", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error":             "invalid_redirect_uri",
+			"error_description": "redirect_uri does not match any registered pattern for this client",
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	_, err := Login(context.Background(), LoginConfig{
+		GuardianURL:  server.URL,
+		ClientID:     "svc_test",
+		CallbackPort: 18087,
+		Timeout:      5 * time.Second,
+		OpenBrowser:  func(string) error { return nil },
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid_redirect_uri")
+}
+
 func TestLoginStateMismatchRejected(t *testing.T) {
 	// IdP that redirects back with the wrong state.
 	mux := http.NewServeMux()
 	var server *httptest.Server
-	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(map[string]any{
-			"authorization_endpoint": server.URL + "/oauth/authorize",
-			"token_endpoint":         server.URL + "/oauth/token",
-		})
+	mux.HandleFunc("/api/v1/oauth/par", func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]any{"request_uri": "urn:guardian:par:x", "expires_in": 90})
 	})
-	mux.HandleFunc("/oauth/authorize", func(w http.ResponseWriter, r *http.Request) {
-		redirect := r.URL.Query().Get("redirect_uri")
+	mux.HandleFunc("/auth/login", func(w http.ResponseWriter, r *http.Request) {
 		go func() {
-			resp, err := http.Get(fmt.Sprintf("%s?code=x&state=wrong", redirect))
+			resp, err := http.Get("http://localhost:18088/auth/callback?token=x&state=wrong")
 			if err == nil {
 				resp.Body.Close()
 			}
@@ -159,17 +161,9 @@ func TestLoginStateMismatchRejected(t *testing.T) {
 	_, err := Login(context.Background(), LoginConfig{
 		GuardianURL:  server.URL,
 		ClientID:     "svc_test",
-		CallbackPort: 18087,
+		CallbackPort: 18088,
 		Timeout:      5 * time.Second,
-		OpenBrowser: func(u string) error {
-			go func() {
-				resp, err := http.Get(u)
-				if err == nil {
-					resp.Body.Close()
-				}
-			}()
-			return nil
-		},
+		OpenBrowser:  browserFetch,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "state mismatch")


### PR DESCRIPTION
Live testing showed `/oauth/authorize` rejects the CLI's `localhost:8085` callback: Guardian only matches **exact registered URIs** there by design — extra redirect URI patterns are honored exclusively via **PAR** (RFC 9126), so user-controlled query params can't exploit wildcard entries (confirmed in guardian's `oidc_provider.go` / `router.go`).

New flow:
1. `POST /api/v1/oauth/par` (client_id, redirect_uri, state) → single-use `request_uri` (90s TTL)
2. Browser → `/auth/login?client_id=...&request_uri=...`
3. Guardian SSO redirects to the localhost callback with `?token=<access JWT>&state=...` — no PKCE/code-exchange step needed (removed)

Verified live against `id.stable.dexus.io`: PAR accepts the registered `http://localhost:8085/auth/callback` pattern and issues a request_uri; fake-IdP tests cover the happy path, PAR rejection, state mismatch, and timeout.