### PR TITLE
Add --target-insecure and --target-ca flags for target TLS

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -21,6 +21,8 @@ var (
 	serverHost        string
 	serverPort        string
 	insecure          bool
+	targetInsecure    bool
+	targetCAFile      string
 	allowedIPs        []string
 	reconnectAttempts int
 	targetHeaders     map[string]string
@@ -43,6 +45,8 @@ var startCmd = &cobra.Command{
 			ServerHost:        serverHost,
 			ServerPort:        serverPort,
 			Insecure:          insecure,
+			TargetInsecure:    targetInsecure,
+			TargetCAFile:      targetCAFile,
 			AllowedIPs:        allowedIPs,
 			ReconnectAttempts: reconnectAttempts,
 			TargetHeaders:     convertMapToHeaders(targetHeaders),
@@ -130,6 +134,8 @@ func init() {
 	startCmd.Flags().StringSliceVarP(&allowedIPs, "allowed-ips", "a", []string{"0.0.0.0/0", "::/0"}, "Allowed IPs")
 	startCmd.Flags().IntVarP(&reconnectAttempts, "reconnect-attempts", "r", 5, "Reconnect attempts")
 	startCmd.Flags().StringToStringVarP(&targetHeaders, "target-headers", "T", map[string]string{}, "Target headers")
+	startCmd.Flags().BoolVar(&targetInsecure, "target-insecure", false, "Skip TLS verification for the target (does not affect the server connection)")
+	startCmd.Flags().StringVar(&targetCAFile, "target-ca", "", "Path to a PEM CA bundle used to verify the target's TLS certificate")
 	startCmd.Flags().StringToStringVarP(&serverHeaders, "server-headers", "S", map[string]string{}, "Server headers")
 	startCmd.Flags().StringVar(&token, "token", "", "JWT authentication token")
 	startCmd.Flags().BoolVarP(&enableTUI, "tui", "u", true, "Enable Terminal User Interface")

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"net/url"
 	"strings"
 	"time"
@@ -93,12 +95,16 @@ func NewTunnel(ctx context.Context, options Options, stateProvider stats.StatePr
 	// HttpResponse message. Responses with unknown length (chunked transfer
 	// encoding, SSE, k8s watch streams, log follows, ...) are streamed back
 	// chunk-by-chunk as HttpResponseStart/Chunk/End messages.
+	targetTLS, err := targetTLSConfig(options)
+	if err != nil {
+		return nil, err
+	}
 	tunnelHttpClient := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: options.Insecure},
+			TLSClientConfig: targetTLS,
 		},
 	}
 
@@ -304,6 +310,30 @@ func streamHttpResponse(
 	}
 }
 
+// targetTLSConfig builds the TLS config used for connections to the target
+// (HTTP and websocket). Verification can be relaxed with TargetInsecure or
+// pinned to a custom CA bundle with TargetCAFile. The legacy Insecure flag is
+// honored for backwards compatibility.
+func targetTLSConfig(options Options) (*tls.Config, error) {
+	cfg := &tls.Config{InsecureSkipVerify: options.Insecure || options.TargetInsecure}
+	if options.TargetCAFile != "" {
+		pem, err := os.ReadFile(options.TargetCAFile)
+		if err != nil {
+			return nil, fmt.Errorf("read target CA file: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return nil, fmt.Errorf("no valid certificates in target CA file %s", options.TargetCAFile)
+		}
+		cfg.RootCAs = pool
+		cfg.InsecureSkipVerify = options.Insecure // CA given: verify against it unless server conn is insecure-forced
+		if options.TargetInsecure {
+			cfg.InsecureSkipVerify = true
+		}
+	}
+	return cfg, nil
+}
+
 func handleWebsocketCreateRequest(
 	ctx context.Context,
 	tunnel *shared.Tunnel,
@@ -327,7 +357,17 @@ func handleWebsocketCreateRequest(
 		// We don't need to add token to WebSocket connections as tunnel access doesn't require auth
 		// The token is only needed for /register endpoint which is handled during initial websocket connection
 
-		rawConn, resp, err := websocket.DefaultDialer.DialContext(ctx, wsUrl.String()+payload.Path, wsHeaders)
+		targetTLS, tlsErr := targetTLSConfig(options)
+		if tlsErr != nil {
+			tunnel.SendResponse(protocol.MessageKindWebsocketCreateResponse, id, &protocol.WebsocketCreateResponsePayload{Error: tlsErr})
+			return
+		}
+		wsDialer := &websocket.Dialer{
+			Proxy:            http.ProxyFromEnvironment,
+			HandshakeTimeout: 45 * time.Second,
+			TLSClientConfig:  targetTLS,
+		}
+		rawConn, resp, err := wsDialer.DialContext(ctx, wsUrl.String()+payload.Path, wsHeaders)
 		if err != nil {
 			tunnel.SendResponse(protocol.MessageKindWebsocketCreateResponse, id, &protocol.WebsocketCreateResponsePayload{Error: err})
 			return

--- a/core/client/options.go
+++ b/core/client/options.go
@@ -355,6 +355,13 @@ type Options struct {
 	ServerHost        string
 	ServerPort        string
 	Insecure          bool
+	// TargetInsecure skips TLS verification when connecting to the target
+	// (e.g. a local k8s apiserver with a self-signed cert). Unlike Insecure,
+	// it does not affect the connection to the tunnel server.
+	TargetInsecure bool
+	// TargetCAFile is a path to a PEM CA bundle used to verify the target's
+	// TLS certificate.
+	TargetCAFile string
 	AllowedIPs        []string
 	ReconnectAttempts int
 	TargetHeaders     http.Header


### PR DESCRIPTION
Needed for Local Vape: tunnel a local k8s apiserver (self-signed cert) over a secure wss connection to the tunnel server.

`--insecure` currently conflates the server connection scheme with target TLS verification. This adds:

- `--target-insecure` — skip TLS verification for the target only
- `--target-ca <file>` — verify the target against a custom PEM CA bundle

Also fixes websocket target dials ignoring TLS options entirely (`websocket.DefaultDialer`).

**Verified live**: `tnl start --name tls-check --target https://localhost:37207 --target-insecure` against a k3d apiserver through tnl.stable.dexus.io → `/version` 200 over wss. Full test suite passes. Client-side only — no server redeploy needed.